### PR TITLE
Fix indentation bug in pracuj scraper

### DIFF
--- a/JobScraper/scrapers/pracuj_scraper.py
+++ b/JobScraper/scrapers/pracuj_scraper.py
@@ -354,7 +354,7 @@ class PracujScraper(BaseScraper):
         )
         if not title_elem:
             meta_title = soup.find("meta", attrs={"property": "og:title"})
-             if meta_title:
+            if meta_title:
                 title = meta_title["content"].strip()
             else:
                 title_tag = soup.find("title")


### PR DESCRIPTION
## Summary
- align `if meta_title:` in pracuj scraper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684530aee2908321ba3ebabb703b3bcb