### PR TITLE
Update pracuj scraper badge extraction

### DIFF
--- a/JobScraper/scrapers/pracuj_scraper.py
+++ b/JobScraper/scrapers/pracuj_scraper.py
@@ -164,7 +164,10 @@ class PracujScraper(BaseScraper):
         }
 
         # ——— 1) Parse badge items using stable data-test attributes ———
-        badge_items = soup.select("li[data-test^='offer-additional-info']")
+        header = soup.select_one("div[data-test='section-offer-header']")
+        badge_items = (
+            header.select("li[data-test^='offer-additional-info']") if header else []
+        )
         for item in badge_items:
             dt = item.get("data-test", "")
             text = item.get_text(strip=True)
@@ -207,6 +210,11 @@ class PracujScraper(BaseScraper):
             min_sal, max_sal = self._extract_salary(salary_text)
             result['salary_min'] = min_sal
             result['salary_max'] = max_sal
+
+        # Truncate long text fields to avoid overflows
+        for key in ["operating_mode", "work_type", "experience_level", "employment_type"]:
+            if result.get(key):
+                result[key] = result[key][:50]
 
         return result
 


### PR DESCRIPTION
## Summary
- handle missing header section when extracting badge info
- truncate scraped text values to 50 characters

## Testing
- `python -m py_compile JobScraper/scrapers/pracuj_scraper.py`
- `python - <<'EOF'
from JobScraper.scrapers.pracuj_scraper import PracujScraper
html = '''<html>
<div data-test='section-offer-header'>
<ul>
<li data-test='offer-additional-info-0'>Mid</li>
<li data-test='offer-additional-info-1'>Full time employment</li>
<li data-test='offer-additional-info-2'>Contract of employment</li>
<li data-test='offer-additional-info-3'>Remote</li>
</ul>
<span data-test='offer-region'>Warszawa</span>
<div data-test='text-earningAmount'>15 000 – 20 000 zł</div>
</div>
<h1 data-test='offer-title'>Data Scientist</h1>
<a data-test='offer-company-name'>Company ABC</a>
</html>'''

scraper = PracujScraper()
job = scraper._parse_job_detail(html, 'https://www.pracuj.pl/oferta/data-scientist,oferta,123456')
print(job)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68456958a34c8321ba8e72adeebd4f43