### PR TITLE
Update workflow paths

### DIFF
--- a/.github/workflows/deploy-justjoin.yml
+++ b/.github/workflows/deploy-justjoin.yml
@@ -3,7 +3,7 @@ name: Deploy JustJoin Scraper
 on:
   push:
     paths:
-      - 'JobMiner/JobScraper/justjoin-scraper/**'
+      - 'JobScraper/justjoin-scraper/**'
 
 jobs:
   deploy:
@@ -20,11 +20,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd JobMiner/JobScraper/justjoin-scraper
+          cd JobScraper/justjoin-scraper
           pip install -r requirements.txt
 
       - name: Deploy to Azure Functions (JustJoin)
         uses: Azure/functions-action@v1
         with:
           app-name: JustJoinScraper  # <– your JustJoin Function App name
-          package: JobMiner/JobScraper/justjoin-scraper
+          package: JobScraper/justjoin-scraper

--- a/.github/workflows/deploy-pracuj.yml
+++ b/.github/workflows/deploy-pracuj.yml
@@ -3,7 +3,7 @@ name: Deploy Pracuj Scraper
 on:
   push:
     paths:
-      - 'JobMiner/JobScraper/pracuj-scraper/**'
+      - 'JobScraper/pracuj-scraper/**'
 
 jobs:
   deploy:
@@ -20,11 +20,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd JobMiner/JobScraper/pracuj-scraper
+          cd JobScraper/pracuj-scraper
           pip install -r requirements.txt
 
       - name: Deploy to Azure Functions (Pracuj)
         uses: Azure/functions-action@v1
         with:
           app-name: JobMiner        # <– your Pracuj Function App name
-          package: JobMiner/JobScraper/pracuj-scraper
+          package: JobScraper/pracuj-scraper


### PR DESCRIPTION
## Summary
- update workflow path patterns for deploy workflows
- drop `JobMiner/` prefix from cd and package paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fa171899c8321a39f4cc6cb4fc860