### PR TITLE
Fix import paths for pracuj scraper

### DIFF
--- a/JobScraper/pracuj-scraper/__init__.py
+++ b/JobScraper/pracuj-scraper/__init__.py
@@ -1,5 +1,5 @@
 import azure.functions as func
-from .pracuj_scraper import PracujScraper
+from pracuj_scraper import PracujScraper
 
 def main(timer: func.TimerRequest):
     scraper = PracujScraper()

--- a/JobScraper/pracuj-scraper/pracuj_scraper.py
+++ b/JobScraper/pracuj-scraper/pracuj_scraper.py
@@ -1,12 +1,15 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from typing import List, Dict, Tuple, Set, Optional
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 import re, math
 import time
-from ..models import JobListing, Skill
-from ..database import insert_job_listing, insert_skill
-from ..base_scraper import BaseScraper
+from models import JobListing, Skill
+from database import insert_job_listing, insert_skill
+from base_scraper import BaseScraper
 import random, os, tempfile, uuid
 from datetime import datetime
 from bs4 import BeautifulSoup


### PR DESCRIPTION
## Summary
- update `JobScraper/pracuj-scraper/pracuj_scraper.py` to prepend parent path and use absolute imports
- align `JobScraper/pracuj-scraper/__init__.py` import with rest of project

## Testing
- `python -m py_compile JobScraper/pracuj-scraper/pracuj_scraper.py JobScraper/pracuj-scraper/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685fa7aed4388321adcd7307425beea7