### PR TITLE
Add .gitignore for Python and Azure artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+.python_packages/
+local.settings.json
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude local virtualenvs, compiled Python artifacts, `.python_packages` and Azure local settings

## Testing
- `python -m py_compile $files`

------
https://chatgpt.com/codex/tasks/task_e_685fb6a19150832196d2025b150e17dc