### PR TITLE
Fix imports for justjoin scraper

### DIFF
--- a/JobScraper/scrapers/justjoin_scraper.py
+++ b/JobScraper/scrapers/justjoin_scraper.py
@@ -3,9 +3,9 @@ import json
 import re
 import time
 from bs4 import BeautifulSoup
-from core.base_scraper   import BaseScraper
-from core.database       import insert_job_listing, insert_skill
-from core.models         import JobListing, Skill
+from .base_scraper import BaseScraper
+from ..database import insert_job_listing, insert_skill
+from ..models import JobListing, Skill
 
 class JustJoinScraper(BaseScraper):
     """


### PR DESCRIPTION
## Summary
- fix `JobScraper/scrapers/justjoin_scraper.py` imports to use package-relative paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685fb69f12388321a6c9f0af41989838